### PR TITLE
Update source.extension.vsixmanifest

### DIFF
--- a/src/Elders.VSE-FormatDocumentOnSave/source.extension.vsixmanifest
+++ b/src/Elders.VSE-FormatDocumentOnSave/source.extension.vsixmanifest
@@ -8,13 +8,13 @@
 You can find the source here: https://github.com/Elders/VSE-FormatDocumentOnSave</Description>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,19.0)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.9,19.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Pro">
+        <InstallationTarget Version="[17.9,19.0)" Id="Microsoft.VisualStudio.Pro">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Enterprise">
+        <InstallationTarget Version="[17.9,19.0)" Id="Microsoft.VisualStudio.Enterprise">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
     </Installation>


### PR DESCRIPTION
Updating the SDK requires the 17.9 to be installed. Running it on LTSC 17.8 didn't work.

So please update the manifest to prevent VS from auto updating!

(after creating a new release with this please pull the original 3.11 release from the store)