### PR TITLE
Change the way the allow and deny list is handled.

### DIFF
--- a/src/Elders.VSE-FormatDocumentOnSave/Configurations/VisualStudioConfiguration.cs
+++ b/src/Elders.VSE-FormatDocumentOnSave/Configurations/VisualStudioConfiguration.cs
@@ -12,13 +12,13 @@ namespace Elders.VSE_FormatDocumentOnSave.Configurations
         public bool IsEnable { get; set; } = true;
 
         [Category("Format Document On Save")]
-        [DisplayName("Allowed extensions")]
-        [Description("Space separated list. For example: [.cs .html .cshtml .vb] Overrides extensions listed in Denied section. When you use [.*] the extensions listed in Denied section will be ignored. Empty value respects all extensions listed in Denied section.")]
+        [DisplayName("Allowed extensions or filenames")]
+        [Description("Space separated list. For example: [.cs .html .cshtml .vb .h .cpp]. The file extension (.cs) or filename (somefile.cs) needs to match an entry in the list to get formatted. The allow list is checked prior to the denie list.")]
         public string Allowed { get; set; } = ".*";
 
         [Category("Format Document On Save")]
-        [DisplayName("Denied extensions")]
-        [Description("Space separated list. For example: [.cs .html .cshtml .vb]")]
+        [DisplayName("Denied extensions or filenames")]
+        [Description("Space separated list. For example: [resource.h]. The file extension (.cs) or filename (somefile.cs) needs to match an entry in the list to NOT get formatted")]
         public string Denied { get; set; } = "";
 
         [Category("Format Document On Save")]

--- a/src/Elders.VSE-FormatDocumentOnSave/source.extension.vsixmanifest
+++ b/src/Elders.VSE-FormatDocumentOnSave/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
 	<Metadata>
 		<Identity Id="2f4fac85-be4e-4d7a-8c74-93cc4389b427" Version="3.13" Language="en-US" Publisher="Elders" />
 		<DisplayName>Format document on Save</DisplayName>
-		<Description xml:space="preserve">Enables auto formatting of the code when you save a file. Visual Studio supports auto formatting of the code with the CTRL+E,D or CTRL+E,F key shortcuts but with this extension the VS command 'Format Document' is executed on Save.
+		<Description xml:space="preserve">Enables auto formatting of the code when you save a file. Visual Studio supports auto formatting of the code with the CTRL+E,D or CTRL+E,F key shortcuts but with this extension the VS command 'Format Document' is executed on Save. Original by Elders (https://github.com/Elders/VSE-FormatDocumentOnSave). Changed allow deny list handling (filename or extension needs to be in allowed but not in denied) 
 
 You can find the source here: https://github.com/Elders/VSE-FormatDocumentOnSave</Description>
 	</Metadata>


### PR DESCRIPTION
I really like your extension but the idea how allowed and denied list is handled (interpreted) is kind of wieeerd :) to me.
I don´t know any system that does it the way the extension does it.

In general speaking i would assume something needs to be in the allowed list to get formatted at all and there may be exclusion from that allowed list. Furthermore i also allow filenames to be part in that list instead of just extensions.

Thus the concept of this PR ist.
- An extension and or filename needs to be in the allowed List but not in the denied list to get formatted

Especially if i would generally like to get **.h** files formatted but e.g. not **resource.h** files which are written by the ide.
This PR solves that issue (or missing functionality)